### PR TITLE
avstplg: Add volume kcontrol support

### DIFF
--- a/avstplg/src/ExtensionMethods.cs
+++ b/avstplg/src/ExtensionMethods.cs
@@ -16,6 +16,21 @@ namespace avstplg
 {
     internal static class ExtensionMethods
     {
+        internal static bool TryInt32(this string value, out int result)
+        {
+            if (value.StartsWith("0x", StringComparison.CurrentCulture))
+                return int.TryParse(value.Substring(2), NumberStyles.HexNumber,
+                                    CultureInfo.CurrentCulture, out result);
+
+            return int.TryParse(value, out result);
+        }
+
+        internal static int ToInt32(this string value)
+        {
+            TryInt32(value, out int result);
+            return result;
+        }
+
         internal static bool TryUInt32(this string value, out uint result)
         {
             if (value.StartsWith("0x", StringComparison.CurrentCulture))

--- a/avstplg/src/SectionProvider.cs
+++ b/avstplg/src/SectionProvider.cs
@@ -627,10 +627,22 @@ namespace avstplg
             sections.Add(data);
 
             var widget = new SectionWidget(template.WidgetName);
-            widget.Type = TPLG_DAPM.SCHEDULER;
             widget.NoPm = true;
             widget.IgnoreSuspend = template.IgnoreSuspend;
             widget.Data = new string[] { data.Identifier };
+
+            if (template.Kcontrol == null || template.Kcontrol.Name == null)
+            {
+                widget.Type = TPLG_DAPM.SCHEDULER;
+            }
+            else
+            {
+                // ASoC does not create kcontrols for widgets of type SCHEDULER.
+                widget.Type = TPLG_DAPM.PGA;
+                widget.Mixer = new string[] { template.Kcontrol.Name };
+                sections.AddRange(GetKcontrolMixerSections(template.Kcontrol));
+            }
+
             sections.Add(widget);
 
             return sections;

--- a/avstplg/src/XmlComponents.cs
+++ b/avstplg/src/XmlComponents.cs
@@ -211,6 +211,8 @@ namespace avstplg
         public string WidgetName { get; set; }
         public bool IgnoreSuspend { get; set; }
         public Path[] Paths;
+        [XmlElement("VolumeMixer")]
+        public Kcontrol Kcontrol { get; set; }
     }
 
     public class Condpath

--- a/avstplg/src/XmlComponents.cs
+++ b/avstplg/src/XmlComponents.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Xml.Serialization;
+using NUcmSerializer;
 
 namespace avstplg
 {
@@ -270,11 +271,33 @@ namespace avstplg
         public DAPMRoute[] Routes;
     }
 
+    public enum KcontrolType : uint
+    {
+        Mixer = TPLG_CTL.VOLSW,
+        Bytes = TPLG_CTL.BYTES,
+        Enum = TPLG_CTL.ENUM,
+    }
+
     public class Kcontrol
     {
+        internal int? max;
+
         [XmlAttribute("id")]
         public uint Id { get; set; }
         public string Name { get; set; }
+        public KcontrolType Type { get; set; }
+        public string Max
+        {
+            get
+            {
+                return max.HasValue ? string.Format("0x{0:X8}", max) : null;
+            }
+            set
+            {
+                if (value != null)
+                    max = value.ToInt32();
+            }
+        }
     }
 
     [XmlRoot]


### PR DESCRIPTION
Currently only Bytes kcontrols are supported. To account for volume controls, generalize method GetKcontrolSections() and introduce GetKcontrolMixerSections() which is based on its Bytes-equivalent.

Most of the fields for a volume control are static - aligned with kernel driver expectations - and thus not all of them are reflected in Kcontrol class.