### PR TITLE
itt: Fix NuGet errors when building against different .NETs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,13 @@ rebuild:
 	msbuild /property:Configuration=$(CONFIGURATION) /t:Rebuild $(MSBUILD_FLAGS) $(SOLUTION_NAME)
 	@chmod +x "./$(OUTDIR)/$(ASSEMBLY_NAME).exe"
 
+#
+# Address NuGet errors such as below by removing assets.json:
+#
+# Your project does not reference ".NETFramework,Version=v4.6.2" framework. Add a reference
+# to ".NETFramework,Version=v4.6.2" in the "TargetFrameworks" property of your project file
+# and then re-run NuGet restore.
+#
 clean:
 	msbuild /property:Configuration=$(CONFIGURATION) /t:Clean $(MSBUILD_FLAGS) $(SOLUTION_NAME)
+	rm -f $(SRCDIR)/obj/project.assets.json


### PR DESCRIPTION
Patchset addresses two topics:
- ~~.NET 6.0 migration~~
- building issues when a .NET 4.6 Framework 

~~.NET 6.0 is the cross-platform successor to .NET Framework. Provides same compiler suite and Base Class Libraries regardless of the target. Only the runtime differs (Mono for iOS, Android and WASM). To keep compatibility with older implementations, rename the solution and the project file. The default names will be used for files targeting the new .NET to make it easy to incorporate unit test suite.~~

In regard to the second subject, errors such as:

  Your project does not reference ".NETFramework,Version=v4.6.2" framework. Add a reference to .NETFramework,Version=v4.6.2" in the "TargetFrameworks" property of your project file and then re-run NuGet restore.

may occur when building the project against .NET Framework v4.6+ and .NET 6.0+ one after the other if obj/ directory is not purged. By removing assets.json when cleaning things up problem is gone.