### PR TITLE
itt: Align ChannelConfig with AudioDSP firmware equivalent

### DIFF
--- a/src/XmlComponents.cs
+++ b/src/XmlComponents.cs
@@ -111,11 +111,8 @@ namespace itt
         [XmlEnum(Name = "CHANNEL_CONFIG_DUAL_MONO")] DUAL_MONO,
         [XmlEnum(Name = "CHANNEL_CONFIG_I2S_DUAL_STEREO_0")] I2S_DUAL_STEREO_0,
         [XmlEnum(Name = "CHANNEL_CONFIG_I2S_DUAL_STEREO_1")] I2S_DUAL_STEREO_1,
-        [XmlEnum(Name = "CHANNEL_CONFIG_4_CHANNEL")] C4_CHANNEL,
-        [XmlEnum(Name = "CHANNEL_CONFIG_7_0")] C7_0,
         [XmlEnum(Name = "CHANNEL_CONFIG_7_1")] C7_1,
-        // No invalid due to inconsistency between INVALID on linux kernel
-        // and 7_0 and 7_1 configurations
+        [XmlEnum(Name = "CHANNEL_CONFIG_INVALID")] INVALID,
     };
 
     public class AudioFormat


### PR DESCRIPTION
Constants 'C4_CHANNEL' and 'C7_0' do not exist on the firmware side whereas 'C7_1' and 'INVALID' do. There are no users for the former two so it is safe to remove them. Doing so also fixes the declaration of 'C7_1' as 0xC is its expected value and allows to bring back 'INVALID'.