### PR TITLE
Fix link to the Building section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ SDK for Intel audio software solutions
 ========================
 
  * [Overview](#overview)
-   * [Building](#)
+   * [Building](#building)
  * [Tools](#tools)
    * [NUcmSerializer](#nucmserializer)
    * [avstplg](#avstplg)


### PR DESCRIPTION
The link is broken, leads to nowhere.