### PR TITLE
Rewrite solutions Makefiles

### DIFF
--- a/NUcmSerializer/Makefile
+++ b/NUcmSerializer/Makefile
@@ -1,13 +1,36 @@
-#Solution configuration, use either "Debug" or "Release"
-CONFIGURATION=Debug
+# Solution configuration, use either "Debug" or "Release".
+CONFIGURATION	= Debug
+FRAMEWORK	= net6.0
+ASSEMBLY_NAME	= NUcmSerializer
+OUTDIR	       := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))/build
+MSBUILD_FLAGS	= -m
+MONO		=
+
+.PHONY: all build clean
 
 all: build
 
-build:
-	msbuild /property:Configuration=$(CONFIGURATION) /t:Build
+# MSBuild for Mono.
+ifneq ($(MONO),)
+SOLUTION_NAME  := $(ASSEMBLY_NAME)_NETFramework.sln
+BINDIR	       := $(OUTDIR)/mono/bin/$(CONFIGURATION)
+OBJDIR	       := $(OUTDIR)/mono/obj/
+MSBUILD	       := msbuild
 
-rebuild:
-	msbuild /property:Configuration=$(CONFIGURATION) /t:Rebuild
+# MSBuild for .NET.
+else
+SOLUTION_NAME  := $(ASSEMBLY_NAME).sln
+BINDIR	       := $(OUTDIR)/bin/$(CONFIGURATION)/$(FRAMEWORK)
+OBJDIR	       := $(OUTDIR)/obj/
+MSBUILD	       := dotnet build
+endif
 
-clean:
-	msbuild /property:Configuration=$(CONFIGURATION) /t:Clean
+# The BaseIntermediateOutputPath must end with a trailing slash.
+%solution:
+	$(MSBUILD) -p:Configuration=$(CONFIGURATION) \
+		   -p:BaseIntermediateOutputPath=$(OBJDIR) \
+		   -p:OutputPath=$(BINDIR) \
+		   -t:$(subst solution,,$@) $(MSBUILD_FLAGS) $(SOLUTION_NAME)
+
+build: buildsolution
+clean: cleansolution

--- a/NUcmSerializer/src/NUcmSerializer_NETFramework.csproj
+++ b/NUcmSerializer/src/NUcmSerializer_NETFramework.csproj
@@ -11,12 +11,14 @@
     <AssemblyName>NUcmSerializer</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <BaseIntermediateOutputPath>..\build\obj\</BaseIntermediateOutputPath>
+    <BaseOutputPath>..\build\bin</BaseOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>$(BaseOutputPath)\$(Configuration)\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -24,7 +26,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>$(BaseOutputPath)\$(Configuration)\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/avstplg/Makefile
+++ b/avstplg/Makefile
@@ -1,20 +1,48 @@
-#Solution configuration, use either "Debug" or "Release"
+# Solution configuration, use either "Debug" or "Release".
 CONFIGURATION	= Debug
+FRAMEWORK	= net6.0
 ASSEMBLY_NAME	= avstplg
-SOLUTION_NAME  := $(ASSEMBLY_NAME)_NETFramework.sln
-SRCDIR	       := src
-OUTDIR	       := $(SRCDIR)/bin/$(CONFIGURATION)
-MSBUILD_FLAGS	= /m
+OUTDIR	       := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))/build
+MSBUILD_FLAGS	= -m
+MONO		=
+
+.PHONY: all build clean
 
 all: build
 
-build:
-	msbuild /property:Configuration=$(CONFIGURATION) /t:Build $(MSBUILD_FLAGS) $(SOLUTION_NAME)
-	@chmod +x "./$(OUTDIR)/$(ASSEMBLY_NAME).exe"
+# MSBuild for Mono. Publishing not supported.
+ifneq ($(MONO),)
+SOLUTION_NAME  := $(ASSEMBLY_NAME)_NETFramework.sln
+BINDIR	       := $(OUTDIR)/mono/bin/$(CONFIGURATION)
+OBJDIR	       := $(OUTDIR)/mono/obj/
+MSBUILD	       := msbuild
 
-rebuild:
-	msbuild /property:Configuration=$(CONFIGURATION) /t:Rebuild $(MSBUILD_FLAGS) $(SOLUTION_NAME)
-	@chmod +x "./$(OUTDIR)/$(ASSEMBLY_NAME).exe"
+# MSBuild for Mono does not mark output as an executable.
+build: buildsolution
+	@chmod +x "$(BINDIR)/$(ASSEMBLY_NAME).exe"
 
-clean:
-	msbuild /property:Configuration=$(CONFIGURATION) /t:Clean $(MSBUILD_FLAGS) $(SOLUTION_NAME)
+# MSBuild for .NET. Publish when building for portability.
+else
+SOLUTION_NAME  := $(ASSEMBLY_NAME).sln
+BINDIR	       := $(OUTDIR)/bin/$(CONFIGURATION)/$(FRAMEWORK)
+OBJDIR	       := $(OUTDIR)/obj/
+MSBUILD	       := dotnet build
+
+# RuntimeIdentifier is a must when publishing to a single file.
+# At the same time, ImportByWildcardBeforeSolution=false bypasses limitation
+# of specifying RID being supported only on project-level, not solution-level.
+MSBUILD_FLAGS  += --use-current-runtime -p:PublishSingleFile=true --no-self-contained \
+		  -p:ImportByWildcardBeforeSolution=false \
+		  -p:PublishDir=$(BINDIR)/publish
+
+build: publishsolution
+endif
+
+# The BaseIntermediateOutputPath must end with a trailing slash.
+%solution:
+	$(MSBUILD) -p:Configuration=$(CONFIGURATION) \
+		   -p:BaseIntermediateOutputPath=$(OBJDIR) \
+		   -p:OutputPath=$(BINDIR) \
+		   -t:$(subst solution,,$@) $(MSBUILD_FLAGS) $(SOLUTION_NAME)
+
+clean: cleansolution

--- a/avstplg/src/avstplg_NETFramework.csproj
+++ b/avstplg/src/avstplg_NETFramework.csproj
@@ -11,13 +11,15 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <BaseIntermediateOutputPath>..\build\obj\</BaseIntermediateOutputPath>
+    <BaseOutputPath>..\build\bin</BaseOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>$(BaseOutputPath)\$(Configuration)\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -26,7 +28,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>$(BaseOutputPath)\$(Configuration)\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/nhltdecode/Makefile
+++ b/nhltdecode/Makefile
@@ -1,24 +1,47 @@
-#Solution configuration, use either "Debug" or "Release"
+# Solution configuration, use either "Debug" or "Release".
 CONFIGURATION	= Debug
+FRAMEWORK	= net6.0
 ASSEMBLY_NAME	= nhltdecode
 SOLUTION_NAME  := $(ASSEMBLY_NAME).sln
-DOTNET_TARGET	= net461
-SRCDIR	       := src
-OUTDIR	       := $(SRCDIR)/bin/$(CONFIGURATION)/$(DOTNET_TARGET)
-MSBUILD_FLAGS	= /m
-MSBUILD_PROPS	= /property:TargetFramework=$(DOTNET_TARGET) \
-		  /property:Configuration=$(CONFIGURATION)
+OUTDIR	       := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))/build
+MSBUILD_FLAGS	= -m -p:TargetFramework=$(FRAMEWORK)
+MONO		=
+
+.PHONY: all build clean
 
 all: build
 
-build:
-	msbuild $(MSBUILD_PROPS) /t:Restore $(MSBUILD_FLAGS) $(SOLUTION_NAME)
-	msbuild $(MSBUILD_PROPS) /t:Build $(MSBUILD_FLAGS) $(SOLUTION_NAME)
-	@chmod +x "./$(OUTDIR)/$(ASSEMBLY_NAME).exe"
+# MSBuild for Mono. Publishing not supported.
+ifneq ($(MONO),)
+BINDIR	       := $(OUTDIR)/mono/bin/$(CONFIGURATION)
+OBJDIR	       := $(OUTDIR)/mono/obj/
+MSBUILD	       := msbuild
 
-rebuild:
-	msbuild $(MSBUILD_PROPS) /t:Rebuild $(MSBUILD_FLAGS) $(SOLUTION_NAME)
-	@chmod +x "./$(OUTDIR)/$(ASSEMBLY_NAME).exe"
+# MSBuild for Mono does not mark output as an executable.
+build: restoresolution buildsolution
+	@chmod +x "$(BINDIR)/$(ASSEMBLY_NAME).exe"
 
-clean:
-	msbuild $(MSBUILD_PROPS) /t:Clean $(MSBUILD_FLAGS) $(SOLUTION_NAME)
+# MSBuild for .NET. Publish when building for portability.
+else
+BINDIR	       := $(OUTDIR)/bin/$(CONFIGURATION)/$(FRAMEWORK)
+OBJDIR	       := $(OUTDIR)/obj/
+MSBUILD	       := dotnet build
+
+# RuntimeIdentifier is a must when publishing to a single file.
+# At the same time, ImportByWildcardBeforeSolution=false bypasses limitation
+# of specifying RID being supported only on project-level, not solution-level.
+MSBUILD_FLAGS  += --use-current-runtime -p:PublishSingleFile=true --no-self-contained \
+		  -p:ImportByWildcardBeforeSolution=false \
+		  -p:PublishDir=$(BINDIR)/publish
+
+build: publishsolution
+endif
+
+# The BaseIntermediateOutputPath must end with a trailing slash.
+%solution:
+	$(MSBUILD) -p:Configuration=$(CONFIGURATION) \
+		   -p:BaseIntermediateOutputPath=$(OBJDIR) \
+		   -p:OutputPath=$(BINDIR) \
+		   -t:$(subst solution,,$@) $(MSBUILD_FLAGS) $(SOLUTION_NAME)
+
+clean: cleansolution

--- a/probe2wav/Makefile
+++ b/probe2wav/Makefile
@@ -1,20 +1,48 @@
-#Solution configuration, use either "Debug" or "Release"
+# Solution configuration, use either "Debug" or "Release".
 CONFIGURATION	= Debug
+FRAMEWORK	= net6.0
 ASSEMBLY_NAME	= probe2wav
-SOLUTION_NAME  := $(ASSEMBLY_NAME)_NETFramework.sln
-SRCDIR	       := src
-OUTDIR	       := $(SRCDIR)/bin/$(CONFIGURATION)
-MSBUILD_FLAGS	= /m
+OUTDIR	       := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))/build
+MSBUILD_FLAGS	= -m
+MONO		=
+
+.PHONY: all build clean
 
 all: build
 
-build:
-	msbuild /property:Configuration=$(CONFIGURATION) /t:Build $(MSBUILD_FLAGS) $(SOLUTION_NAME)
-	@chmod +x "./$(OUTDIR)/$(ASSEMBLY_NAME).exe"
+# MSBuild for Mono. Publishing not supported.
+ifneq ($(MONO),)
+SOLUTION_NAME  := $(ASSEMBLY_NAME)_NETFramework.sln
+BINDIR	       := $(OUTDIR)/mono/bin/$(CONFIGURATION)
+OBJDIR	       := $(OUTDIR)/mono/obj/
+MSBUILD	       := msbuild
 
-rebuild:
-	msbuild /property:Configuration=$(CONFIGURATION) /t:Rebuild $(MSBUILD_FLAGS) $(SOLUTION_NAME)
-	@chmod +x "./$(OUTDIR)/$(ASSEMBLY_NAME).exe"
+# MSBuild for Mono does not mark output as an executable.
+build: buildsolution
+	@chmod +x "$(BINDIR)/$(ASSEMBLY_NAME).exe"
 
-clean:
-	msbuild /property:Configuration=$(CONFIGURATION) /t:Clean $(MSBUILD_FLAGS) $(SOLUTION_NAME)
+# MSBuild for .NET. Publish when building for portability.
+else
+SOLUTION_NAME  := $(ASSEMBLY_NAME).sln
+BINDIR	       := $(OUTDIR)/bin/$(CONFIGURATION)/$(FRAMEWORK)
+OBJDIR	       := $(OUTDIR)/obj/
+MSBUILD	       := dotnet build
+
+# RuntimeIdentifier is a must when publishing to a single file.
+# At the same time, ImportByWildcardBeforeSolution=false bypasses limitation
+# of specifying RID being supported only on project-level, not solution-level.
+MSBUILD_FLAGS  += --use-current-runtime -p:PublishSingleFile=true --no-self-contained \
+		  -p:ImportByWildcardBeforeSolution=false \
+		  -p:PublishDir=$(BINDIR)/publish
+
+build: publishsolution
+endif
+
+# The BaseIntermediateOutputPath must end with a trailing slash.
+%solution:
+	$(MSBUILD) -p:Configuration=$(CONFIGURATION) \
+		   -p:BaseIntermediateOutputPath=$(OBJDIR) \
+		   -p:OutputPath=$(BINDIR) \
+		   -t:$(subst solution,,$@) $(MSBUILD_FLAGS) $(SOLUTION_NAME)
+
+clean: cleansolution

--- a/probe2wav/src/probe2wav_NETFramework.csproj
+++ b/probe2wav/src/probe2wav_NETFramework.csproj
@@ -12,13 +12,15 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <BaseIntermediateOutputPath>..\build\obj\</BaseIntermediateOutputPath>
+    <BaseOutputPath>..\build\bin</BaseOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>$(BaseOutputPath)\$(Configuration)\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -27,7 +29,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>$(BaseOutputPath)\$(Configuration)\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
Currently only MSBuild for Mono is supported whereas the recommended building environment for the solution is MSBuild for .NET.

To support both environments, add MONO variable which when defined will alter several other variables that take part in the building process. FRAMEWORK on the other hand is added to drop the net6.0 hardcode and provide the possibility to compile the solution with other versions of .NET. To avoid one MSBuild interfering with another, output files are put into different locations - both under same root: ./build but in Mono case these are put one level down: ./build/mono.

Project files for .NETFramework is updated accordingly so VisualStudio users are not left behind.

Series iterates over avstplg, nhltdecode, NUcmSerializer and probe2wav solutions.