### PR TITLE
itt: Rewrite Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,48 @@
-#Solution configuration, use either "Debug" or "Release"
+# Solution configuration, use either "Debug" or "Release".
 CONFIGURATION	= Debug
+FRAMEWORK	= net6.0
 ASSEMBLY_NAME	= itt
-SOLUTION_NAME  := $(ASSEMBLY_NAME)_NETFramework.sln
-SRCDIR	       := src
-OUTDIR	       := $(SRCDIR)/bin/$(CONFIGURATION)
-MSBUILD_FLAGS	= /m
+OUTDIR	       := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))/build
+MSBUILD_FLAGS	= -m
+MONO		=
+
+.PHONY: all build clean
 
 all: build
 
-build:
-	msbuild /property:Configuration=$(CONFIGURATION) /t:Build $(MSBUILD_FLAGS) $(SOLUTION_NAME)
-	@chmod +x "./$(OUTDIR)/$(ASSEMBLY_NAME).exe"
+# MSBuild for Mono. Publishing not supported.
+ifneq ($(MONO),)
+SOLUTION_NAME  := $(ASSEMBLY_NAME)_NETFramework.sln
+BINDIR	       := $(OUTDIR)/mono/bin/$(CONFIGURATION)
+OBJDIR	       := $(OUTDIR)/mono/obj/
+MSBUILD	       := msbuild
 
-rebuild:
-	msbuild /property:Configuration=$(CONFIGURATION) /t:Rebuild $(MSBUILD_FLAGS) $(SOLUTION_NAME)
-	@chmod +x "./$(OUTDIR)/$(ASSEMBLY_NAME).exe"
+# MSBuild for Mono does not mark output as an executable.
+build: buildsolution
+	@chmod +x -f "$(BINDIR)/$(ASSEMBLY_NAME).exe" || true
 
-clean:
-	msbuild /property:Configuration=$(CONFIGURATION) /t:Clean $(MSBUILD_FLAGS) $(SOLUTION_NAME)
+# MSBuild for .NET. Publish when building for portability.
+else
+SOLUTION_NAME  := $(ASSEMBLY_NAME).sln
+BINDIR	       := $(OUTDIR)/bin/$(CONFIGURATION)/$(FRAMEWORK)
+OBJDIR	       := $(OUTDIR)/obj/
+MSBUILD	       := dotnet build
+
+# RuntimeIdentifier is a must when publshing to a single file.
+# At the same time, ImportByWildcardBeforeSolution=false bypasses limitation
+# of specifying RID being supported only on project-level, not solution-level.
+MSBUILD_FLAGS  += --use-current-runtime -p:PublishSingleFile=true --no-self-contained \
+		  -p:ImportByWildcardBeforeSolution=false \
+		  -p:PublishDir=$(BINDIR)/publish
+
+build: publishsolution
+endif
+
+# The BaseIntermediateOutputPath must end with a trailing slash.
+%solution:
+	$(MSBUILD) -p:Configuration=$(CONFIGURATION) \
+		   -p:BaseIntermediateOutputPath=$(OBJDIR) \
+		   -p:OutputPath=$(BINDIR) \
+		   -t:$(subst solution,,$@) $(MSBUILD_FLAGS) $(SOLUTION_NAME)
+
+clean: cleansolution

--- a/src/itt_NETFramework.csproj
+++ b/src/itt_NETFramework.csproj
@@ -12,13 +12,15 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
+    <BaseIntermediateOutputPath>..\build\obj\</BaseIntermediateOutputPath>
+    <BaseOutputPath>..\build\bin</BaseOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>$(BaseOutputPath)\$(Configuration)\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -29,7 +31,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>$(BaseOutputPath)\$(Configuration)\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
Currently only MSBuild for Mono is supported whereas the recommended building environment for the solution is MSBuild for .NET.

To support both environments, add MONO variable which when defined will alter several other variables that take part in the building process. FRAMEWORK on the other hand is added to drop the net6.0 hardcode and provide the possibility to compile the solution with other versions of .NET. To avoid one MSBuild interfering with another, output files are put into different locations - both under same root: ./build but in Mono case these are put one level down: ./build/mono.

Project file for .NETFramework is updated accordingly so VisualStudio users are not left behind.