### PR TITLE
ucm: Code simplification and fixes

### DIFF
--- a/NUcmSerializer/src/Components.cs
+++ b/NUcmSerializer/src/Components.cs
@@ -23,11 +23,6 @@ namespace NUcmSerializer
         {
             Identifier = identifier;
         }
-
-        public Section()
-            : this(null)
-        {
-        }
     }
 
     public static class TPLG_CTL
@@ -267,11 +262,6 @@ namespace NUcmSerializer
         {
         }
 
-        protected VendorTuples()
-            : this(null)
-        {
-        }
-
         public abstract int Size();
     }
 
@@ -416,11 +406,6 @@ namespace NUcmSerializer
 
         public SectionControl(string identifier)
             : base(identifier)
-        {
-        }
-
-        public SectionControl()
-            : this(null)
         {
         }
     }

--- a/NUcmSerializer/src/Components.cs
+++ b/NUcmSerializer/src/Components.cs
@@ -689,11 +689,17 @@ namespace NUcmSerializer
 
             set
             {
-                string[] substrs = value.Split(new[] { ',' });
-
                 Formats.Clear();
-                foreach (var s in substrs)
-                    Formats.Add((PCM_FORMAT)Enum.Parse(typeof(PCM_FORMAT), s));
+                if (value == null)
+                    return;
+
+                string[] substrs = value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                                        .Select(s => s.Trim())
+                                        .Distinct().ToArray();
+
+                foreach (string s in substrs)
+                    if (Enum.GetNames<PCM_FORMAT>().Contains(s))
+                        Formats.Add(Enum.Parse<PCM_FORMAT>(s));
             }
         }
 
@@ -708,14 +714,27 @@ namespace NUcmSerializer
 
             set
             {
-                string[] substrs = value.Split(new[] { ',' });
-
                 Rates.Clear();
-                foreach (var s in substrs)
+                if (value == null)
+                    return;
+
+                string[] substrs = value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                                        .Select(s => s.Trim())
+                                        .Distinct().ToArray();
+
+                foreach (string s in substrs)
                 {
+                    string tmp;
+
+                    if (s[0] == '_')
+                        continue;
+
                     if (char.IsDigit(s[0]))
-                        s.Insert(0, "_");
-                    Rates.Add((PCM_RATE)Enum.Parse(typeof(PCM_RATE), s));
+                        tmp = s.Insert(0, "_");
+                    else
+                        tmp = s;
+                    if (Enum.GetNames<PCM_RATE>().Contains(tmp))
+                        Rates.Add(Enum.Parse<PCM_RATE>(tmp));
                 }
             }
         }

--- a/NUcmSerializer/src/TypeHelper.cs
+++ b/NUcmSerializer/src/TypeHelper.cs
@@ -120,7 +120,7 @@ namespace NUcmSerializer
             {
                 if (substr.StartsWith("0x", StringComparison.CurrentCulture) &&
                     byte.TryParse(substr.Substring(2), NumberStyles.HexNumber,
-                                        CultureInfo.CurrentCulture, out byte val))
+                                  CultureInfo.CurrentCulture, out byte val))
                     result.Add(val);
                 else if (byte.TryParse(substr, out val))
                     result.Add(val);
@@ -139,7 +139,7 @@ namespace NUcmSerializer
             {
                 if (substr.StartsWith("0x", StringComparison.CurrentCulture) &&
                     ushort.TryParse(substr.Substring(2), NumberStyles.HexNumber,
-                                        CultureInfo.CurrentCulture, out ushort val))
+                                    CultureInfo.CurrentCulture, out ushort val))
                     result.Add(val);
                 else if (ushort.TryParse(substr, out val))
                     result.Add(val);
@@ -158,7 +158,7 @@ namespace NUcmSerializer
             {
                 if (substr.StartsWith("0x", StringComparison.CurrentCulture) &&
                     uint.TryParse(substr.Substring(2), NumberStyles.HexNumber,
-                                        CultureInfo.CurrentCulture, out uint val))
+                                  CultureInfo.CurrentCulture, out uint val))
                     result.Add(val);
                 else if (uint.TryParse(substr, out val))
                     result.Add(val);

--- a/NUcmSerializer/src/TypeHelper.cs
+++ b/NUcmSerializer/src/TypeHelper.cs
@@ -56,7 +56,7 @@ namespace NUcmSerializer
                 return TokenType.Tuple;
             if (type.IsVendorArrayType())
                 return TokenType.VendorArray;
-            if (type.IsSubclassOf(typeof(Section)))
+            if (type.IsSubclassOf(typeof(Section)) || type == typeof(Section))
                 return TokenType.Section;
 
             return TokenType.None;

--- a/NUcmSerializer/src/TypeHelper.cs
+++ b/NUcmSerializer/src/TypeHelper.cs
@@ -50,13 +50,13 @@ namespace NUcmSerializer
         {
             if (type.IsSimpleType())
                 return TokenType.Element;
-            else if (type.IsSimpleArrayType())
+            if (type.IsSimpleArrayType())
                 return TokenType.Array;
-            else if (type.IsSimpleTupleType())
+            if (type.IsSimpleTupleType())
                 return TokenType.Tuple;
-            else if (type.IsVendorArrayType())
+            if (type.IsVendorArrayType())
                 return TokenType.VendorArray;
-            else if (type.IsSubclassOf(typeof(Section)))
+            if (type.IsSubclassOf(typeof(Section)))
                 return TokenType.Section;
 
             return TokenType.None;

--- a/NUcmSerializer/src/TypeHelper.cs
+++ b/NUcmSerializer/src/TypeHelper.cs
@@ -98,8 +98,7 @@ namespace NUcmSerializer
                 }
 
                 TypeConverter conv = TypeDescriptor.GetConverter(type);
-                if (conv != null)
-                    return conv.ConvertFromString(value);
+                return conv.ConvertFromString(value);
             }
             catch (NotSupportedException)
             {

--- a/NUcmSerializer/src/UcmReader.cs
+++ b/NUcmSerializer/src/UcmReader.cs
@@ -36,6 +36,9 @@ namespace NUcmSerializer
 
         public UcmReader(Stream stream, Encoding encoding)
         {
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+
             this.encoding = encoding;
             if (encoding == null)
                 reader = new StreamReader(stream);

--- a/NUcmSerializer/src/UcmSerializer.cs
+++ b/NUcmSerializer/src/UcmSerializer.cs
@@ -22,6 +22,8 @@ namespace NUcmSerializer
 
         public void Serialize(Stream stream, IEnumerable<Section> sections, Encoding encoding)
         {
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
             if (sections == null)
                 throw new ArgumentNullException("sections");
 
@@ -45,6 +47,9 @@ namespace NUcmSerializer
 
         public IEnumerable<Section> Deserialize(Stream stream, Encoding encoding)
         {
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+
             List<Section> result = new List<Section>();
             Section section;
 

--- a/NUcmSerializer/src/UcmWriter.cs
+++ b/NUcmSerializer/src/UcmWriter.cs
@@ -89,6 +89,9 @@ namespace NUcmSerializer
 
         public UcmWriter(Stream stream, Encoding encoding)
         {
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+
             this.encoding = encoding;
             if (encoding == null)
                 writer = new StreamWriter(stream);


### PR DESCRIPTION
A range of fixes aiming to improve code quality.

It starts with removal of unused ctors for the abstract classes - unused and not intended to be used by inheriting classes. While most of remaining patches are pretty self explanatory, the largest change rewrites FormatsString and RatesString property. Goal is to remove any ambiguity by improving string-parsing mechanism and dropping empty entries before doing so.