### PR TITLE
avstplg: Allow for specifying significant bits of a PCM

### DIFF
--- a/avstplg/src/SectionProvider.cs
+++ b/avstplg/src/SectionProvider.cs
@@ -757,6 +757,7 @@ namespace avstplg
             section.Rates.UnionWith(rates.Select(s => s.ToRate()));
             section.ChannelsMax = channels.Max();
             section.ChannelsMin = channels.Min();
+            section.SigBits = caps.SigBits;
 
             return section;
         }

--- a/avstplg/src/XmlComponents.cs
+++ b/avstplg/src/XmlComponents.cs
@@ -243,6 +243,7 @@ namespace avstplg
         public string Formats { get; set; }
         public string Rates { get; set; }
         public string Channels { get; set; }
+        public uint SigBits { get; set; }
     }
 
     public class FEDAI


### PR DESCRIPTION
Hint the default significant-bits value of a stream to the kernel by supplying PCM capabilities section with SigBits. The field is already part of the ASoC topology standard.