### PR TITLE
avstplg: Align with internal repository

### DIFF
--- a/avstplg/Makefile
+++ b/avstplg/Makefile
@@ -6,6 +6,11 @@ OUTDIR	       := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))/build
 MSBUILD_FLAGS	= -m
 MONO		=
 
+# The BaseIntermediateOutputPath must end with a trailing slash.
+override MSBUILD_FLAGS += -p:Configuration=$(CONFIGURATION)
+override MSBUILD_FLAGS += -p:OutputPath=$(BINDIR)
+override MSBUILD_FLAGS += -p:BaseIntermediateOutputPath=$(OBJDIR)
+
 .PHONY: all build clean
 
 all: build
@@ -28,21 +33,20 @@ BINDIR	       := $(OUTDIR)/bin/$(CONFIGURATION)/$(FRAMEWORK)
 OBJDIR	       := $(OUTDIR)/obj/
 MSBUILD	       := dotnet build
 
-# RuntimeIdentifier is a must when publishing to a single file.
-# At the same time, ImportByWildcardBeforeSolution=false bypasses limitation
-# of specifying RID being supported only on project-level, not solution-level.
-MSBUILD_FLAGS  += --use-current-runtime -p:PublishSingleFile=true --no-self-contained \
-		  -p:ImportByWildcardBeforeSolution=false \
-		  -p:PublishDir=$(BINDIR)/publish
+# RuntimeIdentifier (RID) is a must when publishing to a single file. Set it
+# based on the current machine with --use-current-runtime.
+# Due to certain limitations, specifying RID is supported only on project-level,
+# not solution-level. ImportByWildcardBeforeSolution=false bypasses that.
+
+override MSBUILD_FLAGS += --use-current-runtime --no-self-contained
+override MSBUILD_FLAGS += -p:ImportByWildcardBeforeSolution=false
+override MSBUILD_FLAGS += -p:PublishSingleFile=true
+override MSBUILD_FLAGS += -p:PublishDir=$(BINDIR)/publish
 
 build: publishsolution
 endif
 
-# The BaseIntermediateOutputPath must end with a trailing slash.
 %solution:
-	$(MSBUILD) -p:Configuration=$(CONFIGURATION) \
-		   -p:BaseIntermediateOutputPath=$(OBJDIR) \
-		   -p:OutputPath=$(BINDIR) \
-		   -t:$(subst solution,,$@) $(MSBUILD_FLAGS) $(SOLUTION_NAME)
+	$(MSBUILD) $(SOLUTION_NAME) -t:$(subst solution,,$@) $(MSBUILD_FLAGS)
 
 clean: cleansolution

--- a/avstplg/Makefile
+++ b/avstplg/Makefile
@@ -1,7 +1,7 @@
 # Solution configuration, use either "Debug" or "Release".
 CONFIGURATION	= Debug
 FRAMEWORK	= net6.0
-ASSEMBLY_NAME	= avstplg
+ASSEMBLY_NAME  := avstplg
 OUTDIR	       := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))/build
 MSBUILD_FLAGS	= -m
 MONO		=

--- a/avstplg/src/SectionProvider.cs
+++ b/avstplg/src/SectionProvider.cs
@@ -951,6 +951,7 @@ namespace avstplg
             string identifier;
 
             var pcm = new SectionPCM(fedai.Name);
+            pcm.ID = fedai.Id;
             pcm.IgnoreSuspend = fedai.IgnoreSuspend;
             if (fedai.CaptureCapabilities != null)
             {

--- a/avstplg/src/SectionProvider.cs
+++ b/avstplg/src/SectionProvider.cs
@@ -996,18 +996,18 @@ namespace avstplg
             {
                 control.Ops = new Ops("ctl")
                 {
-                    Get = 257,
-                    Put = 257,
-                    Info = TPLG_CTL.VOLSW,
+                    Get = AVS_CTL_OPS.VOLUME,
+                    Put = AVS_CTL_OPS.VOLUME,
+                    Info = AVS_CTL_OPS.VOLUME,
                 };
             }
             else if (kctrl.Name.Contains("Switch"))
             {
                 control.Ops = new Ops("ctl")
                 {
-                    Get = 258,
-                    Put = 258,
-                    Info = TPLG_CTL.VOLSW,
+                    Get = AVS_CTL_OPS.MUTE,
+                    Put = AVS_CTL_OPS.MUTE,
+                    Info = AVS_CTL_OPS.MUTE,
                 };
             }
             control.Access = new[]

--- a/avstplg/src/SectionProvider.cs
+++ b/avstplg/src/SectionProvider.cs
@@ -15,6 +15,19 @@ namespace avstplg
 {
     public static class SectionProvider
     {
+        /* ASoC core supports up to 8 channels for kcontrols. */
+        static ChannelMap[] DefaultChannelMap =
+        {
+            new ChannelMap(ChannelName.FrontLeft),
+            new ChannelMap(ChannelName.FrontRight),
+            new ChannelMap(ChannelName.RearLeft),
+            new ChannelMap(ChannelName.RearRight),
+            new ChannelMap(ChannelName.FrontCenter),
+            new ChannelMap(ChannelName.SideLeft),
+            new ChannelMap(ChannelName.SideRight),
+            new ChannelMap(ChannelName.RearCenter),
+        };
+
         static Tuple<string, U> GetTuple<T, U>(T token, U value)
             where T : struct
         {
@@ -1016,6 +1029,7 @@ namespace avstplg
                 CTL_ELEM_ACCESS.VOLATILE,
             };
             control.Data = data.Identifier;
+            control.Channel = DefaultChannelMap.Take(kctrl.NumChannels).ToArray();
             sections.Add(control);
 
             return sections;

--- a/avstplg/src/SectionProvider.cs
+++ b/avstplg/src/SectionProvider.cs
@@ -1030,6 +1030,7 @@ namespace avstplg
             };
             control.Data = data.Identifier;
             control.Channel = DefaultChannelMap.Take(kctrl.NumChannels).ToArray();
+            control.Invert = kctrl.Invert;
             sections.Add(control);
 
             return sections;

--- a/avstplg/src/SectionProvider.cs
+++ b/avstplg/src/SectionProvider.cs
@@ -319,6 +319,12 @@ namespace avstplg
                 wordTuples.Add(GetTuple(AVS_TKN_MODCFG.WHM_DMA_TYPE_U32, module.whmDMAType.Value));
             if (module.WhmDMABufferSize != null)
                 wordTuples.Add(GetTuple(AVS_TKN_MODCFG.WHM_DMABUFF_SIZE_U32, module.WhmDMABufferSize.Value));
+            if (module.PeakVolVolume.HasValue)
+                wordTuples.Add(GetTuple(AVS_TKN_MODCFG.PEAKVOL_VOLUME_U32, module.PeakVolVolume.Value));
+            if (module.PeakVolCurveType.HasValue)
+                wordTuples.Add(GetTuple(AVS_TKN_MODCFG.PEAKVOL_CURVE_TYPE_U32, module.PeakVolCurveType.Value));
+            if (module.PeakVolCurveDuration.HasValue)
+                wordTuples.Add(GetTuple(AVS_TKN_MODCFG.PEAKVOL_CURVE_DURATION_U32, module.PeakVolCurveDuration.Value));
 
             var words = new VendorTuples<uint>();
             words.Tuples = wordTuples.ToArray();

--- a/avstplg/src/SectionProvider.cs
+++ b/avstplg/src/SectionProvider.cs
@@ -330,7 +330,7 @@ namespace avstplg
             if (module.WhmOutAudioFormatId.HasValue)
                 wordTuples.Add(GetTuple(AVS_TKN_MODCFG.WHM_OUT_AFMT_ID_U32, module.WhmOutAudioFormatId.Value));
             if (module.WhmBlobFormatId.HasValue)
-                wordTuples.Add(GetTuple(AVS_TKN_MODCFG.WHM_BLOB_FMT_ID_U32, module.WhmBlobFormatId.Value));
+                wordTuples.Add(GetTuple(AVS_TKN_MODCFG.WHM_BLOB_AFMT_ID_U32, module.WhmBlobFormatId.Value));
             if (module.WhmWakeTickPeriod.HasValue)
                 wordTuples.Add(GetTuple(AVS_TKN_MODCFG.WHM_WAKE_TICK_PERIOD_U32, module.WhmWakeTickPeriod.Value));
             if (module.WhmVirtualIndex != null)

--- a/avstplg/src/SectionProvider.cs
+++ b/avstplg/src/SectionProvider.cs
@@ -738,8 +738,14 @@ namespace avstplg
             {
                 // ASoC does not create kcontrols for widgets of type SCHEDULER.
                 widget.Type = TPLG_DAPM.PGA;
-                widget.Mixer = new string[] { template.Kcontrol.Name };
+
+                List<string> mixerSettings = new List<string> { template.Kcontrol.Name };
+                if (template.MuteKcontrol != null && template.MuteKcontrol.Name != null)
+                    mixerSettings.Add(template.MuteKcontrol.Name);
+                widget.Mixer = mixerSettings.ToArray();
                 sections.AddRange(GetKcontrolMixerSections(template.Kcontrol));
+                if (template.MuteKcontrol != null && template.MuteKcontrol.Name != null)
+                    sections.AddRange(GetKcontrolMixerSections(template.MuteKcontrol));
             }
 
             sections.Add(widget);
@@ -921,12 +927,24 @@ namespace avstplg
             var control = new SectionControlMixer(kctrl.Name);
             // TODO: replace hardcodes below with descriptive constants
             control.Max = kctrl.max;
-            control.Ops = new Ops("ctl")
+            if (kctrl.Name.Contains("Volume"))
             {
-                Get = 257,
-                Put = 257,
-                Info = TPLG_CTL.VOLSW,
-            };
+                control.Ops = new Ops("ctl")
+                {
+                    Get = 257,
+                    Put = 257,
+                    Info = TPLG_CTL.VOLSW,
+                };
+            }
+            else if (kctrl.Name.Contains("Switch"))
+            {
+                control.Ops = new Ops("ctl")
+                {
+                    Get = 258,
+                    Put = 258,
+                    Info = TPLG_CTL.VOLSW,
+                };
+            }
             control.Access = new[]
             {
                 CTL_ELEM_ACCESS.READWRITE,

--- a/avstplg/src/UcmTokens.cs
+++ b/avstplg/src/UcmTokens.cs
@@ -20,6 +20,7 @@ namespace avstplg
         NUM_BINDINGS_U32,
         NUM_CONDPATH_TMPLS_U32,
         NUM_INIT_CONFIGS_U32,
+        NUM_NHLT_CONFIGS_U32,
     }
 
     public enum AVS_TKN_LIBRARY
@@ -106,6 +107,8 @@ namespace avstplg
         PEAKVOL_VOLUME_U32,
         PEAKVOL_CURVE_TYPE_U32,
         PEAKVOL_CURVE_DURATION_U32,
+
+        CPR_NHLT_CONFIG_ID_U32,
     }
 
     public enum AVS_TKN_PPLCFG
@@ -200,6 +203,12 @@ namespace avstplg
     {
         ID_U32 = 2401,
         PARAM_U8,
+        LENGTH_U32,
+    }
+
+    public enum AVS_TKN_NHLT_CONFIG
+    {
+        ID_U32 = 2501,
         LENGTH_U32,
     }
 }

--- a/avstplg/src/UcmTokens.cs
+++ b/avstplg/src/UcmTokens.cs
@@ -101,6 +101,11 @@ namespace avstplg
         WHM_DMABUFF_SIZE_U32,
         WHM_VINDEX_U8,
         WHM_BLOB_FMT_ID_U32,
+
+        PEAKVOL_CHANNEL_ID_U32, // Reserved
+        PEAKVOL_VOLUME_U32,
+        PEAKVOL_CURVE_TYPE_U32,
+        PEAKVOL_CURVE_DURATION_U32,
     }
 
     public enum AVS_TKN_PPLCFG

--- a/avstplg/src/UcmTokens.cs
+++ b/avstplg/src/UcmTokens.cs
@@ -98,10 +98,10 @@ namespace avstplg
         WHM_REF_AFMT_ID_U32,
         WHM_OUT_AFMT_ID_U32,
         WHM_WAKE_TICK_PERIOD_U32,
+        WHM_VINDEX_U8,
         WHM_DMA_TYPE_U32,
         WHM_DMABUFF_SIZE_U32,
-        WHM_VINDEX_U8,
-        WHM_BLOB_FMT_ID_U32,
+        WHM_BLOB_AFMT_ID_U32,
 
         PEAKVOL_CHANNEL_ID_U32, // Reserved
         PEAKVOL_VOLUME_U32,

--- a/avstplg/src/UcmTokens.cs
+++ b/avstplg/src/UcmTokens.cs
@@ -211,4 +211,11 @@ namespace avstplg
         ID_U32 = 2501,
         LENGTH_U32,
     }
+
+    public static class AVS_CTL_OPS
+    {
+        /* Lower values reserved by ASoC core. */
+        public const uint VOLUME = 257;
+        public const uint MUTE = 258;
+    }
 }

--- a/avstplg/src/XmlComponents.cs
+++ b/avstplg/src/XmlComponents.cs
@@ -271,6 +271,8 @@ namespace avstplg
 
     public class FEDAI
     {
+        [XmlAttribute("id")]
+        public uint Id { get; set; }
         [XmlAttribute("name")]
         public string Name { get; set; }
         public bool IgnoreSuspend { get; set; }

--- a/avstplg/src/XmlComponents.cs
+++ b/avstplg/src/XmlComponents.cs
@@ -148,6 +148,7 @@ namespace avstplg
         public uint? PeakVolVolume { get; set; }
         public uint? PeakVolCurveType { get; set; }
         public uint? PeakVolCurveDuration { get; set; }
+        public uint? CprNHLTConfigId { get; set; }
     }
 
     public class ModuleInitConfig
@@ -155,6 +156,13 @@ namespace avstplg
         [XmlAttribute("id")]
         public uint Id { get; set; }
         public byte Param { get; set; }
+        public HexBLOB Data { get; set; }
+    }
+
+    public class NHLTConfig
+    {
+        [XmlAttribute("id")]
+        public uint Id { get; set; }
         public HexBLOB Data { get; set; }
     }
 
@@ -328,6 +336,7 @@ namespace avstplg
         public ModuleConfigBase[] ModuleConfigsBase;
         public ModuleConfigExt[] ModuleConfigsExt;
         public ModuleInitConfig[] ModuleInitConfigs;
+        public NHLTConfig[] NHLTConfigs;
         public PipelineConfig[] PipelineConfigs;
         public Binding[] Bindings;
         public PathTemplate[] PathTemplates;

--- a/avstplg/src/XmlComponents.cs
+++ b/avstplg/src/XmlComponents.cs
@@ -324,6 +324,7 @@ namespace avstplg
                     max = value.ToInt32();
             }
         }
+        public bool Invert { get; set; }
         public int NumChannels { get; set; }
     }
 

--- a/avstplg/src/XmlComponents.cs
+++ b/avstplg/src/XmlComponents.cs
@@ -152,7 +152,6 @@ namespace avstplg
         [XmlAttribute("id")]
         public uint Id { get; set; }
         public byte Param { get; set; }
-        public uint Length { get; set; }
         public HexBLOB Data { get; set; }
     }
 

--- a/avstplg/src/XmlComponents.cs
+++ b/avstplg/src/XmlComponents.cs
@@ -324,6 +324,7 @@ namespace avstplg
                     max = value.ToInt32();
             }
         }
+        public int NumChannels { get; set; }
     }
 
     [XmlRoot]

--- a/avstplg/src/XmlComponents.cs
+++ b/avstplg/src/XmlComponents.cs
@@ -226,6 +226,8 @@ namespace avstplg
         public Path[] Paths;
         [XmlElement("VolumeMixer")]
         public Kcontrol Kcontrol { get; set; }
+        [XmlElement("MuteMixer")]
+        public Kcontrol MuteKcontrol { get; set; }
     }
 
     public class Condpath

--- a/avstplg/src/XmlComponents.cs
+++ b/avstplg/src/XmlComponents.cs
@@ -145,6 +145,9 @@ namespace avstplg
             }
         }
         public uint? WhmDMABufferSize { get; set; }
+        public uint? PeakVolVolume { get; set; }
+        public uint? PeakVolCurveType { get; set; }
+        public uint? PeakVolCurveDuration { get; set; }
     }
 
     public class ModuleInitConfig

--- a/avstplg/src/avstplg_NETFramework.csproj
+++ b/avstplg/src/avstplg_NETFramework.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ExtensionMethods.cs" />
+    <Compile Include="Hex.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SectionProvider.cs" />


### PR DESCRIPTION
In order to remove maintenance burden and remove confusion between internal and public repository upstream missing changes.

This PR contains a set of various changes for avstplg utility.

Add support for:
* PeakVol module
* Exposing Mute control for modules which support that
* Overriding NHLT with builtin configuration
* Multichannel controls
* IDs on FE DAIs