### PR TITLE
probe2wav: Align with internal repository

### DIFF
--- a/probe2wav/src/ChunkHeader.cs
+++ b/probe2wav/src/ChunkHeader.cs
@@ -22,15 +22,23 @@ namespace probe2wav
     {
         public uint ProbeId;
         public uint ProbeFormat;
-        public ulong Timestamp;
+        public uint TimestampHigh;
+        public uint TimestampLow;
         public uint DataSize;
 
         public string ProbeIdStr => "0x" + ProbeId.ToString("X8").TrimStart('0');
 
         // While checksum theoretically is 8 bytes only least significant 4 bytes contains valid data.
         // Most significant 4 bytes should be equal to 0.
-        public ulong ExpectedChecksum =>
-                (ProbeId + ProbeFormat + Timestamp + DataSize + Constants.SyncPattern) & 0xFFFFFFFF;
+        public ulong ExpectedChecksum
+        {
+            get
+            {
+                return (ProbeId + ProbeFormat + TimestampHigh + TimestampLow + DataSize +
+                    Constants.SyncPattern) & 0xFFFFFFFF;
+            }
+        }
+
         public bool Wav => ProbeId != Constants.BaseFWProbeId;
 
         public static ChunkHeader Create(BinaryReader binaryReader)
@@ -38,7 +46,8 @@ namespace probe2wav
             ChunkHeader header;
             header.ProbeId = binaryReader.ReadUInt32();
             header.ProbeFormat = binaryReader.ReadUInt32();
-            header.Timestamp = binaryReader.ReadUInt64();
+            header.TimestampHigh = binaryReader.ReadUInt32();
+            header.TimestampLow = binaryReader.ReadUInt32();
             header.DataSize = binaryReader.ReadUInt32();
 
             return header;

--- a/probe2wav/src/ProbeExtractor.cs
+++ b/probe2wav/src/ProbeExtractor.cs
@@ -102,6 +102,7 @@ namespace probe2wav
                     }
                     else
                     {
+                        Console.WriteLine($"Incorrect checksum at offset: {binaryReader.BaseStream.Position - 8}");
                         checksumMismatchCount++;
                     }
                 }
@@ -119,7 +120,7 @@ namespace probe2wav
                 Console.WriteLine($"Conversion finished - {chunkSuccessCount}/{allChunksCount} chunks correct");
 
             if (checksumMismatchCount > 0 || syncPatternSearchCount > 1 || formatMismatchCount > 0)
-                throw new Exception($"Checksum mismatch: {checksumMismatchCount}, Sync pattern search: {syncPatternSearchCount}, Format mismatch: {formatMismatchCount}");
+                Console.WriteLine($"Checksum mismatch: {checksumMismatchCount}, Sync pattern search: {syncPatternSearchCount}, Format mismatch: {formatMismatchCount}");
         }
 
         private int SearchSyncPattern(BinaryReader reader)

--- a/probe2wav/src/ProbeWriter.cs
+++ b/probe2wav/src/ProbeWriter.cs
@@ -80,7 +80,7 @@ namespace probe2wav
             writer.Write((uint)Format.SampleRate);
             writer.Write(Format.SampleRate * Format.BlockAlign); // Average bytes per second
             writer.Write((ushort)Format.BlockAlign);
-            writer.Write((ushort)Format.ValidBits);
+            writer.Write((ushort)Format.ContainerBits);
             writer.Write(Encoding.ASCII.GetBytes("data"));
             writer.Write((uint)bytesWritten);
         }


### PR DESCRIPTION
In order to remove maintenance burden and remove confusion between internal and public repository upstream missing changes.

This PR contains fixes for probe2wav when parsing logs from probe.